### PR TITLE
Pull request for the unary bug fix

### DIFF
--- a/src/main/java/edu/washington/cs/knowitall/nlp/extraction/ChunkedBinaryExtraction.java
+++ b/src/main/java/edu/washington/cs/knowitall/nlp/extraction/ChunkedBinaryExtraction.java
@@ -154,7 +154,7 @@ public class ChunkedBinaryExtraction extends SpanExtraction {
         if (allowUnaryRelations && results.isEmpty()) {
             for (ChunkedArgumentExtraction arg1 : arg1s) {
                 Range dummyRange = new Range(rel.getRange().getStart()
-                        + rel.getRange().getLength() + 1, 0);
+                        + rel.getRange().getLength(), 0);
                 ChunkedArgumentExtraction arg2 = new ChunkedArgumentExtraction(
                         rel.getSentence(), dummyRange, rel);
                 ChunkedBinaryExtraction extr = new ChunkedBinaryExtraction(rel,

--- a/src/test/java/edu/washington/cs/knowitall/extractor/ReVerbExtractorTest.java
+++ b/src/test/java/edu/washington/cs/knowitall/extractor/ReVerbExtractorTest.java
@@ -31,15 +31,6 @@ public class ReVerbExtractorTest  {
         if (relaxedReverb == null) {
         	relaxedReverb = new ReVerbExtractor(0, false, false, true);
         }
-        /**if(regReverb == null && noFilters == false) {
-        	regReverb = new ReVerbExtractor();
-        }
-        else if(noFilters == true){
-        	regReverb = null;
-        }
-        if (noFilters == true && relaxedReverb == null) {
-        	relaxedReverb = new ReVerbExtractor(0, false, false, true);
-        }*/
         expected = new HashSet<String>();
     }
 
@@ -600,6 +591,21 @@ public class ReVerbExtractorTest  {
         );
     	assertFalse(got.contains("(himself, invented, the phonograph)"));
         assertTrue(got.contains("(Edison, invented, the phonograph)"));
+    }
+
+    @Test
+    public void testUnaryCases() throws Exception{
+        reverb = relaxedReverb;
+        got = extractTriples("people on earth slow down",
+                "NNS IN NN VB RP",
+                "B-NP B-PP B-NP B-VP B-PP");
+        assertTrue(got.contains("(earth, slow down, )"));
+
+        got = extractTriples("It rained",
+                "PRP VBD",
+                "B-NP B-VP");
+        assertTrue(got.contains("(It, rained, )"));
+
     }
 
 }


### PR DESCRIPTION
Tony

I have added a fix that removes the IndexOutOfBounds exception for some unary extractions. 

The hack for creating a unary relation, had an incorrect range for the missing argument. 

I have added a test case for this bug. 

~ Niranjan.
